### PR TITLE
Add Payment Contact Address

### DIFF
--- a/types.go
+++ b/types.go
@@ -112,7 +112,8 @@ type Ethereum struct {
 		} `json:"infura"`
 	} `json:"connection"`
 	Contracts struct {
-		RTCAddress string `json:"rtc_address"`
+		RTCAddress             string `json:"rtc_address"`
+		PaymentContractAddress string `json:"payment_contract_address"`
 	} `json:"contracts"`
 }
 


### PR DESCRIPTION
Adds a field to the ethereum contracts config section for the payment contract address