### PR TITLE
Add Section For API Keys

### DIFF
--- a/types.go
+++ b/types.go
@@ -12,6 +12,7 @@ type TemporalConfig struct {
 	Sendgrid    `json:"sendgrid,omitempty"`
 	Ethereum    `json:"ethereum,omitempty"`
 	Wallets     `json:"wallets,omitempty"`
+	APIKeys     `json:"api_keys,omitempty"`
 }
 
 // API configures the Temporal API
@@ -126,4 +127,9 @@ type Wallets struct {
 	DASH string `json:"dash"`
 	BTC  string `json:"btc"`
 	LTC  string `json:"ltc"`
+}
+
+// APIKeys are the various API keys we use
+type APIKeys struct {
+	ChainRider string `json:"chain_rider"`
 }


### PR DESCRIPTION
This can be expanded in the future to include additional API keys for any service temporal relies on.