### PR TITLE
RabbitMQ TLS + Delegator

### DIFF
--- a/types.go
+++ b/types.go
@@ -87,7 +87,11 @@ type MINIO struct {
 
 // RabbitMQ configures Temporal's connection to a RabbitMQ instance
 type RabbitMQ struct {
-	URL string `json:"url"`
+	URL       string `json:"url"`
+	TLSConfig struct {
+		CertFile string `json:"cert_file"`
+		KeyFile  string `json:"key_file"`
+	} `json:"tls_config"`
 }
 
 // AWS configures Temporal's connection to AWS
@@ -186,4 +190,8 @@ type Orchestrator struct {
 		CertPath string `json:"cert"`
 		KeyPath  string `json:"key"`
 	} `json:"tls"`
+	Delegator struct {
+		Host string `json:"host"`
+		Port string `json:"port"`
+	} `json:"delegator"`
 }

--- a/types.go
+++ b/types.go
@@ -2,20 +2,20 @@ package config
 
 // TemporalConfig defines Temporal configuration fields
 type TemporalConfig struct {
-	API          `json:"api,omitempty"`
-	Database     `json:"database,omitempty"`
-	IPFS         `json:"ipfs,omitempty"`
-	IPFSCluster  `json:"ipfs_cluster,omitempty"`
-	MINIO        `json:"minio,omitempty"`
-	RabbitMQ     `json:"rabbitmq,omitempty"`
-	AWS          `json:"aws,omitempty"`
-	Sendgrid     `json:"sendgrid,omitempty"`
-	Ethereum     `json:"ethereum,omitempty"`
-	Wallets      `json:"wallets,omitempty"`
-	APIKeys      `json:"api_keys,omitempty"`
-	Endpoints    `json:"endpoints,omitempty"`
-	Orchestrator `json:"orchestrator,omitempty"`
-	LogDir       string `json:"log_dir,omitempty"`
+	API         `json:"api,omitempty"`
+	Database    `json:"database,omitempty"`
+	IPFS        `json:"ipfs,omitempty"`
+	IPFSCluster `json:"ipfs_cluster,omitempty"`
+	MINIO       `json:"minio,omitempty"`
+	RabbitMQ    `json:"rabbitmq,omitempty"`
+	AWS         `json:"aws,omitempty"`
+	Sendgrid    `json:"sendgrid,omitempty"`
+	Ethereum    `json:"ethereum,omitempty"`
+	Wallets     `json:"wallets,omitempty"`
+	APIKeys     `json:"api_keys,omitempty"`
+	Endpoints   `json:"endpoints,omitempty"`
+	Nexus       `json:"Nexus,omitempty"`
+	LogDir      string `json:"log_dir,omitempty"`
 }
 
 // API configures the Temporal API
@@ -181,8 +181,9 @@ type Endpoints struct {
 	} `json:"krab"`
 }
 
-// Orchestrator defines options for the IPFS orchestrator
-type Orchestrator struct {
+// Nexus defines options for the Nexus, our private network
+// management tool for IPFS.
+type Nexus struct {
 	Host string `json:"host"`
 	Port string `json:"port"`
 	Key  string `json:"key"`
@@ -191,7 +192,6 @@ type Orchestrator struct {
 		KeyPath  string `json:"key"`
 	} `json:"tls"`
 	Delegator struct {
-		Host string `json:"host"`
 		Port string `json:"port"`
 	} `json:"delegator"`
 }

--- a/types.go
+++ b/types.go
@@ -14,7 +14,7 @@ type TemporalConfig struct {
 	Wallets     `json:"wallets,omitempty"`
 	APIKeys     `json:"api_keys,omitempty"`
 	Endpoints   `json:"endpoints,omitempty"`
-	Nexus       `json:"Nexus,omitempty"`
+	Nexus       `json:"nexus,omitempty"`
 	LogDir      string `json:"log_dir,omitempty"`
 }
 


### PR DESCRIPTION
Allows for the usage of client-based certificate authentication with rabbitmq
Allows for specifying delegator ports