### PR TITLE
Enable Environment Variable Based Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.11"
+  - "1.13"
 
 install:
   - go get -u golang.org/x/lint/golint

--- a/config.go
+++ b/config.go
@@ -3,12 +3,17 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/vrischmann/envconfig"
 	"io/ioutil"
 	"os"
 )
 
 // LoadConfig loads a TemporalConfig from given filepath
 func LoadConfig(configPath string) (*TemporalConfig, error) {
+	// if configPath is empty, load from env
+	if configPath == "" {
+		return LoadConfigFromEnv()
+	}
 	raw, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
@@ -22,6 +27,13 @@ func LoadConfig(configPath string) (*TemporalConfig, error) {
 	tCfg.setDefaults()
 
 	return &tCfg, nil
+}
+
+// LoadConfigFromEnv is used to load a TemporalConfig object us env vars
+func LoadConfigFromEnv() (*TemporalConfig, error) {
+	cfg := &TemporalConfig{}
+	err := envconfig.Init(cfg)
+	return cfg, err
 }
 
 // GenerateConfig writes a empty TemporalConfig template to given filepath

--- a/config.go
+++ b/config.go
@@ -6,13 +6,23 @@ import (
 	"github.com/vrischmann/envconfig"
 	"io/ioutil"
 	"os"
+	"reflect"
 )
 
 // LoadConfig loads a TemporalConfig from given filepath
 func LoadConfig(configPath string) (*TemporalConfig, error) {
 	// if configPath is empty, load from env
 	if configPath == "" {
-		return LoadConfigFromEnv()
+		conf, err := LoadConfigFromEnv()
+		if err != nil {
+			return nil, err
+		}
+		// this will pass if we failed to pull config
+		// from the environment, and will then default
+		// to config file path based loading
+		if !reflect.DeepEqual(&TemporalConfig{}, conf) {
+			return conf, nil
+		}
 	}
 	raw, err := ioutil.ReadFile(configPath)
 	if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/RTradeLtd/config/v2"
@@ -27,7 +28,16 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	if conf.API.Connection.ListenAddress != "0.0.0.0:9090" {
 		t.Fatal("bad api listen address")
 	}
+	if reflect.DeepEqual(&config.TemporalConfig{}, conf) {
+		t.Fatal("should not be equal")
+	}
+	os.Unsetenv("API_CONNECTION_LISTENADDRESS")
+	conf, err = config.LoadConfig("")
+	if err == nil {
+		t.Fatal("error expected")
+	}
 }
+
 func TestGenerateConfigFailure(t *testing.T) {
 	testConf := "/root/toor/config.json"
 	if err := config.GenerateConfig(testConf); err == nil {

--- a/config_test.go
+++ b/config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/RTradeLtd/config"
+	"github.com/RTradeLtd/config/v2"
 )
 
 func TestGenerateAndLoadConfig(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,16 @@ func TestGenerateAndLoadConfig(t *testing.T) {
 	}
 }
 
+func TestLoadConfigFromEnv(t *testing.T) {
+	os.Setenv("API_CONNECTION_LISTENADDRESS", "0.0.0.0:9090")
+	conf, err := config.LoadConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf.API.Connection.ListenAddress != "0.0.0.0:9090" {
+		t.Fatal("bad api listen address")
+	}
+}
 func TestGenerateConfigFailure(t *testing.T) {
 	testConf := "/root/toor/config.json"
 	if err := config.GenerateConfig(testConf); err == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/RTradeLtd/config/v2
 
 go 1.12
+
+require (
+	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/vrischmann/envconfig v1.2.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RTradeLtd/config/v2
 
-go 1.12
+go 1.13
 
 require (
 	github.com/stretchr/testify v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/vrischmann/envconfig v1.2.0 h1:5/u4fI34/g3m0SdTQj/6f3r640jv9E5+yTXIZOWsxk0=
+github.com/vrischmann/envconfig v1.2.0/go.mod h1:c5DuUlkzfsnspy1g7qiqryPCsW+NjsrLsYq4zhwsoHo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/types.go
+++ b/types.go
@@ -2,7 +2,7 @@ package config
 
 // TemporalConfig defines Temporal configuration fields
 type TemporalConfig struct {
-	V3          `json:"v3"`
+	V3          `json:"v3,omitempty"`
 	API         `json:"api,omitempty"`
 	APIKeys     `json:"api_keys,omitempty"`
 	AWS         `json:"aws,omitempty"`

--- a/types.go
+++ b/types.go
@@ -2,21 +2,21 @@ package config
 
 // TemporalConfig defines Temporal configuration fields
 type TemporalConfig struct {
-	V3          `json:"v3,omitempty"`
-	API         `json:"api,omitempty"`
-	APIKeys     `json:"api_keys,omitempty"`
-	AWS         `json:"aws,omitempty"`
-	Database    `json:"database,omitempty"`
-	Services    `json:"services,omitempty"`
-	Ethereum    `json:"ethereum,omitempty"`
-	IPFSCluster `json:"ipfs_cluster,omitempty"`
-	IPFS        `json:"ipfs,omitempty"`
-	Pay         `json:"pay,omitempty"`
-	RabbitMQ    `json:"rabbitmq,omitempty"`
-	Sendgrid    `json:"sendgrid,omitempty"`
-	Stripe      `json:"stripe,omitempty"`
-	Wallets     `json:"wallets,omitempty"`
-	LogDir      string `json:"log_dir,omitempty"`
+	V3          `json:"v3,omitempty" envconfig:"optional"`
+	API         `json:"api,omitempty" envconfig:"optional"`
+	APIKeys     `json:"api_keys,omitempty" envconfig:"optional"`
+	AWS         `json:"aws,omitempty" envconfig:"optional"`
+	Database    `json:"database,omitempty" envconfig:"optional"`
+	Services    `json:"services,omitempty" envconfig:"optional"`
+	Ethereum    `json:"ethereum,omitempty" envconfig:"optional"`
+	IPFSCluster `json:"ipfs_cluster,omitempty" envconfig:"optional"`
+	IPFS        `json:"ipfs,omitempty" envconfig:"optional"`
+	Pay         `json:"pay,omitempty" envconfig:"optional"`
+	RabbitMQ    `json:"rabbitmq,omitempty" envconfig:"optional"`
+	Sendgrid    `json:"sendgrid,omitempty" envconfig:"optional"`
+	Stripe      `json:"stripe,omitempty" envconfig:"optional"`
+	Wallets     `json:"wallets,omitempty" envconfig:"optional"`
+	LogDir      string `json:"log_dir,omitempty" envconfig:"optional"`
 }
 
 // API configures the Temporal API


### PR DESCRIPTION
Using the semantics defined in https://github.com/vrischmann/envconfig we can enable complete environment variable based configuration.

If you attempt to run `LoadConfig` without providing a config file path, it will attempt to load from environment variables instead.

Basically the syntax is `STRUCT_FIELD` so:

```golang
type Foo struct {
  type Bar struct {
      Dog string
     CatDog string
  }
}
```

`FOO_BAR_DOG` or `FOO_BAR_CATDOG`